### PR TITLE
Remove typed parameters in ClientConfig

### DIFF
--- a/src/V4/ClientConfig.php
+++ b/src/V4/ClientConfig.php
@@ -17,7 +17,7 @@ class ClientConfig
     public $file; // The basename of the package (package/package.php)
     public $envatoItemId;
 
-    public function __construct(string $serverUrl, array $config)
+    public function __construct($serverUrl, $config)
     {
         $this->serverUrl = untrailingslashit($serverUrl);
 


### PR DESCRIPTION
Hallo @Capevace,

ich kam heute endlich zum Testen der neuen Version 4 Deines WordPress Updaters. Alles hat einwandfrei funktioniert - laufe lokal auf PHP Version 7.2. Viele meiner Kunden arbeiten aber noch mit PHP 5.6+, weshalb der Konstruktor von ClientConfig.php nicht funktioniert:

```php
public function __construct(string $serverUrl, array $config)
```

wirft bei PHP 5.6+ folgende Fehlermeldung:

**PHP Catchable fatal error:  Argument 1 passed to Smoolabs\WPU\V4\ClientConfig::__construct() must be an instance of Smoolabs\WPU\V4\string, string given, called in /home/ubuntu/workspace/wp-content/plugins/real-category-library/inc/general/Core.class.php on line 171 and defined in /home/ubuntu/workspace/wp-content/plugins/real-category-library/vendor/smoolabs/wordpress-plugin-updater/src/V4/ClientConfig.php on line 20**

Du solltest in Deinem Updater zwingend PHP 5.6+ supporten, da (leider) noch zu viele WordPress Installationen auf dieser Version laufen: https://wordpress.org/about/stats/

Siehe auch: http://php.net/manual/de/functions.arguments.php#functions.arguments.type-declaration.types

Beste Grüße,
Matthias :-)